### PR TITLE
Add Run & Learn UI skeleton

### DIFF
--- a/app/src/main/java/com/pacemaker/ai/ui/community/CommunityScreen.kt
+++ b/app/src/main/java/com/pacemaker/ai/ui/community/CommunityScreen.kt
@@ -1,9 +1,52 @@
 package com.pacemaker.ai.ui.community
 
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun CommunityScreen() {
-    Text("Community")
+    var selectedTab by remember { mutableStateOf(0) }
+    val tabs = listOf("챌린지", "피드")
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        TabRow(selectedTabIndex = selectedTab) {
+            tabs.forEachIndexed { index, title ->
+                Tab(
+                    selected = selectedTab == index,
+                    onClick = { selectedTab = index },
+                    text = { Text(title) }
+                )
+            }
+        }
+
+        when (selectedTab) {
+            0 -> LazyColumn(modifier = Modifier.padding(16.dp)) {
+                items(5) { index ->
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 8.dp)
+                    ) {
+                        Text("챌린지 $index", modifier = Modifier.padding(16.dp))
+                    }
+                }
+            }
+
+            1 -> LazyColumn(modifier = Modifier.padding(16.dp)) {
+                items(5) { index ->
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 8.dp)
+                    ) {
+                        Text("피드 $index", modifier = Modifier.padding(16.dp))
+                    }
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/pacemaker/ai/ui/components/AppTopBar.kt
+++ b/app/src/main/java/com/pacemaker/ai/ui/components/AppTopBar.kt
@@ -1,0 +1,21 @@
+package com.pacemaker.ai.ui.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun AppTopBar(title: String, onMenuClick: () -> Unit) {
+    CenterAlignedTopAppBar(
+        title = { Text(title) },
+        navigationIcon = {
+            IconButton(onClick = onMenuClick) {
+                Icon(Icons.Default.Menu, contentDescription = "menu")
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/pacemaker/ai/ui/components/CardItem.kt
+++ b/app/src/main/java/com/pacemaker/ai/ui/components/CardItem.kt
@@ -1,0 +1,23 @@
+package com.pacemaker.ai.ui.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun CardItem(title: String, subtitle: String, icon: ImageVector) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(modifier = Modifier.padding(16.dp), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Icon(icon, contentDescription = null)
+            Column {
+                Text(title)
+                Text(subtitle)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/pacemaker/ai/ui/components/CircularProgressGauge.kt
+++ b/app/src/main/java/com/pacemaker/ai/ui/components/CircularProgressGauge.kt
@@ -1,0 +1,18 @@
+package com.pacemaker.ai.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun CircularProgressGauge(progress: Float, label: String) {
+    Column(modifier = Modifier.fillMaxWidth().padding(8.dp)) {
+        CircularProgressIndicator(progress = progress)
+        Text(label)
+    }
+}

--- a/app/src/main/java/com/pacemaker/ai/ui/dashboard/HomeDashboardScreen.kt
+++ b/app/src/main/java/com/pacemaker/ai/ui/dashboard/HomeDashboardScreen.kt
@@ -1,12 +1,70 @@
 package com.pacemaker.ai.ui.dashboard
 
-import androidx.compose.material3.Button
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.pacemaker.ai.ui.components.AppTopBar
+import com.pacemaker.ai.ui.components.CircularProgressGauge
 
 @Composable
 fun HomeDashboardScreen(onStartSession: () -> Unit) {
-    Button(onClick = onStartSession) {
-        Text("Start Session")
+    Scaffold(
+        topBar = { AppTopBar(title = "Dashboard", onMenuClick = {}) }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text("오늘 세션")
+                    Spacer(Modifier.height(8.dp))
+                    Button(onClick = onStartSession) {
+                        Icon(Icons.Default.PlayArrow, contentDescription = null)
+                        Spacer(Modifier.width(4.dp))
+                        Text("시작")
+                    }
+                }
+            }
+
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text("KPI")
+                    Spacer(Modifier.height(8.dp))
+                    CircularProgressGauge(progress = 0.5f, label = "체중 감량")
+                    Spacer(Modifier.height(8.dp))
+                    Text("VO₂max")
+                    Text("주간 목표 달성률")
+                }
+            }
+
+            Text("챌린지")
+            LazyRow {
+                items((1..3).toList()) { index ->
+                    Card(
+                        modifier = Modifier
+                            .size(width = 180.dp, height = 100.dp)
+                            .padding(end = 8.dp)
+                    ) {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text("배너 $index")
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/pacemaker/ai/ui/navigation/BottomNavBar.kt
+++ b/app/src/main/java/com/pacemaker/ai/ui/navigation/BottomNavBar.kt
@@ -1,0 +1,38 @@
+package com.pacemaker.ai.ui.navigation
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DirectionsRun
+import androidx.compose.material.icons.filled.Groups
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+
+@Composable
+fun BottomNavBar(current: Screen, onNavigate: (Screen) -> Unit) {
+    NavigationBar {
+        NavItem(Screen.Dashboard, Icons.Default.Home, current, onNavigate)
+        NavItem(Screen.SessionPreview, Icons.Default.DirectionsRun, current, onNavigate)
+        NavItem(Screen.Community, Icons.Default.Groups, current, onNavigate)
+        NavItem(Screen.Settings, Icons.Default.Settings, current, onNavigate)
+    }
+}
+
+@Composable
+private fun NavItem(
+    screen: Screen,
+    icon: ImageVector,
+    current: Screen,
+    onNavigate: (Screen) -> Unit
+) {
+    NavigationBarItem(
+        selected = current == screen,
+        onClick = { onNavigate(screen) },
+        icon = { Icon(icon, contentDescription = screen.route) },
+        label = { Text(screen.route) }
+    )
+}

--- a/app/src/main/java/com/pacemaker/ai/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/pacemaker/ai/ui/navigation/NavGraph.kt
@@ -5,12 +5,14 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import com.pacemaker.ai.ui.community.CommunityScreen
 import com.pacemaker.ai.ui.dashboard.HomeDashboardScreen
-import com.pacemaker.ai.ui.feedback.FeedbackScreen
 import com.pacemaker.ai.ui.onboarding.OnboardingScreen
+import com.pacemaker.ai.ui.session.FeedbackScreen
 import com.pacemaker.ai.ui.session.RunSessionScreen
 import com.pacemaker.ai.ui.session.SessionPreviewScreen
 import com.pacemaker.ai.ui.session.SummaryScreen
+import com.pacemaker.ai.ui.settings.SettingsScreen
 
 sealed class Screen(val route: String) {
     data object Onboarding : Screen("onboarding")
@@ -19,6 +21,8 @@ sealed class Screen(val route: String) {
     data object RunSession : Screen("run_session")
     data object Summary : Screen("summary")
     data object Feedback : Screen("feedback")
+    data object Community : Screen("community")
+    data object Settings : Screen("settings")
 }
 
 @Composable
@@ -45,6 +49,12 @@ fun AppNavGraph(navController: NavHostController) {
         }
         composable(Screen.Feedback.route) {
             FeedbackScreen(onDone = { navController.navigate(Screen.Dashboard.route) })
+        }
+        composable(Screen.Community.route) {
+            CommunityScreen()
+        }
+        composable(Screen.Settings.route) {
+            SettingsScreen()
         }
     }
 }

--- a/app/src/main/java/com/pacemaker/ai/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/pacemaker/ai/ui/onboarding/OnboardingScreen.kt
@@ -1,12 +1,39 @@
 package com.pacemaker.ai.ui.onboarding
 
+import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun OnboardingScreen(onFinish: () -> Unit) {
-    Button(onClick = onFinish) {
-        Text("Finish Onboarding")
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.SpaceBetween,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Run & Learn",
+            style = MaterialTheme.typography.headlineMedium,
+            modifier = Modifier.padding(top = 32.dp)
+        )
+
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Button(onClick = { /*TODO*/ }) { Text("감량") }
+            Spacer(modifier = Modifier.height(8.dp))
+            Button(onClick = { /*TODO*/ }) { Text("지구력") }
+            Spacer(modifier = Modifier.height(8.dp))
+            Button(onClick = { /*TODO*/ }) { Text("스트레스") }
+        }
+
+        Button(onClick = onFinish, modifier = Modifier.fillMaxWidth()) {
+            Text("다음")
+        }
     }
 }

--- a/app/src/main/java/com/pacemaker/ai/ui/session/FeedbackScreen.kt
+++ b/app/src/main/java/com/pacemaker/ai/ui/session/FeedbackScreen.kt
@@ -1,12 +1,34 @@
-package com.pacemaker.ai.ui.feedback
+package com.pacemaker.ai.ui.session
 
+import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun FeedbackScreen(onDone: () -> Unit) {
-    Button(onClick = onDone) {
-        Text("Done")
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.SpaceBetween,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("오늘 세션 강도는 어땠나요?")
+
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Button(onClick = { /*TODO*/ }) { Text("쉬웠다") }
+            Spacer(modifier = Modifier.height(8.dp))
+            Button(onClick = { /*TODO*/ }) { Text("적당했다") }
+            Spacer(modifier = Modifier.height(8.dp))
+            Button(onClick = { /*TODO*/ }) { Text("힘들었다") }
+        }
+
+        Button(onClick = onDone, modifier = Modifier.fillMaxWidth()) {
+            Text("완료")
+        }
     }
 }

--- a/app/src/main/java/com/pacemaker/ai/ui/session/RunSessionScreen.kt
+++ b/app/src/main/java/com/pacemaker/ai/ui/session/RunSessionScreen.kt
@@ -1,12 +1,55 @@
 package com.pacemaker.ai.ui.session
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun RunSessionScreen(onFinished: () -> Unit) {
-    Button(onClick = onFinished) {
-        Text("End Session")
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                Brush.verticalGradient(listOf(Color.Red, Color.Transparent))
+            )
+            .padding(16.dp)
+    ) {
+        Column(
+            modifier = Modifier.align(Alignment.Center),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text("페이스 5'30\"")
+            Text("거리 3.2 km")
+            Text("심박수 150")
+        }
+
+        Row(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 32.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Button(onClick = { /*TODO*/ }) {
+                Icon(Icons.Default.Pause, contentDescription = null)
+                Spacer(Modifier.width(4.dp))
+                Text("일시정지")
+            }
+            Button(onClick = onFinished) {
+                Icon(Icons.Default.Stop, contentDescription = null)
+                Spacer(Modifier.width(4.dp))
+                Text("종료")
+            }
+        }
     }
 }

--- a/app/src/main/java/com/pacemaker/ai/ui/session/SessionPreviewScreen.kt
+++ b/app/src/main/java/com/pacemaker/ai/ui/session/SessionPreviewScreen.kt
@@ -1,12 +1,35 @@
 package com.pacemaker.ai.ui.session
 
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun SessionPreviewScreen(onStart: () -> Unit) {
-    Button(onClick = onStart) {
-        Text("Begin Run")
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.SpaceBetween,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text("세션 이름", style = MaterialTheme.typography.headlineSmall)
+            Text("길이: 35분")
+            Text("5′ 러닝/2′ 걷기 × 4")
+        }
+
+        Button(onClick = onStart, modifier = Modifier.fillMaxWidth()) {
+            Icon(Icons.Default.PlayArrow, contentDescription = null)
+            Spacer(Modifier.width(4.dp))
+            Text("시작")
+        }
     }
 }

--- a/app/src/main/java/com/pacemaker/ai/ui/session/SummaryScreen.kt
+++ b/app/src/main/java/com/pacemaker/ai/ui/session/SummaryScreen.kt
@@ -1,12 +1,62 @@
 package com.pacemaker.ai.ui.session
 
-import androidx.compose.material3.Button
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Map
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun SummaryScreen(onNext: () -> Unit) {
-    Button(onClick = onNext) {
-        Text("Next")
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Box(
+                modifier = Modifier
+                    .height(150.dp)
+                    .fillMaxWidth(),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(Icons.Default.Map, contentDescription = null)
+            }
+        }
+
+        LazyColumn(modifier = Modifier.weight(1f)) {
+            items(5) { index ->
+                ListItem(
+                    headlineContent = { Text("랩 ${index + 1}") },
+                    supportingContent = { Text("00:00") }
+                )
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .height(100.dp)
+                .fillMaxWidth(),
+            contentAlignment = Alignment.Center
+        ) {
+            Text("심박수 그래프")
+        }
+
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text("칼로리")
+                Text("평균 페이스")
+                Text("VO₂max")
+            }
+        }
+
+        Button(onClick = onNext, modifier = Modifier.fillMaxWidth()) {
+            Text("피드백 입력")
+        }
     }
 }

--- a/app/src/main/java/com/pacemaker/ai/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pacemaker/ai/ui/settings/SettingsScreen.kt
@@ -1,9 +1,40 @@
 package com.pacemaker.ai.ui.settings
 
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun SettingsScreen() {
-    Text("Settings")
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        Text("프로필 정보: 이름, 체중")
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text("목표 수정", modifier = Modifier.weight(1f))
+            IconButton(onClick = { /*TODO*/ }) {
+                Icon(Icons.Default.Edit, contentDescription = null)
+            }
+        }
+
+        Column {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("HealthConnect", modifier = Modifier.weight(1f))
+                Switch(checked = false, onCheckedChange = { })
+            }
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("GPS", modifier = Modifier.weight(1f))
+                Switch(checked = false, onCheckedChange = { })
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add skeleton screens for onboarding, dashboard, session and more
- create navigation bottom bar and expand NavGraph
- add UI components (AppTopBar, CardItem, CircularProgressGauge)

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access jarfile gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_686d2e45bd80832991b3d961e229cf26