### PR TITLE
Fix Hilt plugin resolution

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,8 @@ pluginManagement {
 
     resolutionStrategy {
         eachPlugin {
-            if (requested.id.id == "dagger.hilt.android.plugin") {
+            if (requested.id.id == "dagger.hilt.android.plugin" ||
+                requested.id.id == "com.google.dagger.hilt.android") {
                 useModule("com.google.dagger:hilt-android-gradle-plugin:${requested.version}")
             }
         }


### PR DESCRIPTION
## Summary
- handle both Hilt plugin IDs in pluginManagement so the build can resolve

## Testing
- `gradle --stacktrace tasks` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686d4ad6440083298ee7b2f725c28806