### PR TITLE
Fix Hilt plugin ID

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("com.android.application")
     kotlin("android")
     kotlin("kapt")
-    id("com.google.dagger.hilt.android")
+    id("dagger.hilt.android.plugin")
 }
 
 android {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,6 @@ plugins {
     id("com.android.library") version "8.4.1" apply false
     kotlin("android") version "1.9.23" apply false
     kotlin("kapt") version "1.9.23" apply false
-    id("com.google.dagger.hilt.android") version "2.51" apply false
+    id("dagger.hilt.android.plugin") version "2.51" apply false
 }
 

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("com.android.application")
     kotlin("android")
     kotlin("kapt")
-    id("com.google.dagger.hilt.android")
+    id("dagger.hilt.android.plugin")
 }
 
 android {


### PR DESCRIPTION
## Summary
- use `dagger.hilt.android.plugin` instead of `com.google.dagger.hilt.android`

## Testing
- `gradle tasks --stacktrace`

------
https://chatgpt.com/codex/tasks/task_e_686d5bea24f483299d07b02d4d648570