### PR TITLE
Fix build by using system icons and theme

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,10 +4,10 @@
     <application
         android:allowBackup="true"
         android:label="Run-Learn"
-        android:icon="@mipmap/ic_launcher"
-        android:roundIcon="@mipmap/ic_launcher_round"
+        android:icon="@android:drawable/sym_def_app_icon"
+        android:roundIcon="@android:drawable/sym_def_app_icon"
         android:supportsRtl="true"
-        android:theme="@style/Theme.RunLearn">
+        android:theme="@style/Theme.Material3.DayNight.NoActionBar">
 
         <!-- android:exported 추가 -->
         <activity

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -4,9 +4,9 @@
         android:allowBackup="true"
         android:label="Run-Learn Wear"
         android:supportsRtl="true"
-        android:icon="@mipmap/ic_launcher"
-        android:roundIcon="@mipmap/ic_launcher_round"
-        android:theme="@style/Theme.RunLearn">
+        android:icon="@android:drawable/sym_def_app_icon"
+        android:roundIcon="@android:drawable/sym_def_app_icon"
+        android:theme="@style/Theme.Material3.DayNight.NoActionBar">
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
## Summary
- use default system icons instead of missing mipmap icons
- switch to a standard Material3 theme

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68707d2f017483298aea66e8480ebf8e