### PR TITLE
Fix JVM target mismatch

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,6 +9,11 @@ android {
     namespace = "com.runlearn.ai"
     compileSdk = 34
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
+    }
+
     defaultConfig {
         applicationId = "com.runlearn.ai"
         minSdk = 26
@@ -53,4 +58,8 @@ dependencies {
 
 kapt {
     correctErrorTypes = true
+}
+
+kotlin {
+    jvmToolchain(21)
 }

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -9,6 +9,11 @@ android {
     namespace = "com.runlearn.ai.wear"
     compileSdk = 34
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
+    }
+
     defaultConfig {
         applicationId = "com.runlearn.ai.wear"
         minSdk = 26
@@ -46,4 +51,8 @@ dependencies {
 
 kapt {
     correctErrorTypes = true
+}
+
+kotlin {
+    jvmToolchain(21)
 }


### PR DESCRIPTION
## Summary
- target Java 21 for compile options in app and wear modules
- use Kotlin JVM toolchain 21

## Testing
- `gradle testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870877e281c83298890a4a03bd53aa6