### PR TITLE
Fix JVM toolchain configuration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,3 +63,9 @@ kapt {
 kotlin {
     jvmToolchain(21)
 }
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -56,3 +56,9 @@ kapt {
 kotlin {
     jvmToolchain(21)
 }
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}


### PR DESCRIPTION
## Summary
- ensure AGP uses Java 21 toolchain by configuring the `java` toolchain in both modules

## Testing
- `gradle -q help`
- `gradle -q tasks --all`

------
https://chatgpt.com/codex/tasks/task_e_687089450d8483298f8c6dca66ffd1e5